### PR TITLE
paho-mqtt version 2.0.0 - breaking change

### DIFF
--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -25,7 +25,7 @@ class MqqtHandler (object):
 	
 	def connect(self):
 		settings_message = ""
-		self.mqtt_client = paho.Client(self.client_id, True)
+		self.mqtt_client = paho.Client(paho.CallbackAPIVersion.VERSION1, self.client_id, True)
 
 		if self.authentication:
 			self.mqtt_client.username_pw_set(self.user, self.password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-paho-mqtt
-PyYAML
-pyserial
+paho_mqtt==2.0.0
+pyserial==3.5
+PyYAML==6.0.1


### PR DESCRIPTION
Hi Matthijs, thanks for this project! I'm using it in my Kubernetes homelab :) 

Recently the paho-mqtt package got updated to version [2.0.0 ](https://github.com/eclipse/paho.mqtt.python/releases) which introduced a breaking change.  
This PR fixes:
  - mqtt client setup with CallbackAPIVersion.VERSION1