### PR TITLE
Support URL-style serial ports

### DIFF
--- a/kamstrup_meter.py
+++ b/kamstrup_meter.py
@@ -88,26 +88,21 @@ class kamstrup(object):
 		self.serial_port = port
 		self.parameters = parameters
 
+		kwargs = dict(
+			baudrate=1200,
+			parity=serial.PARITY_NONE,
+			stopbits=serial.STOPBITS_TWO,
+			bytesize=serial.EIGHTBITS,
+			timeout=2.0
+		)
+
 		try:
 			if "://" in self.serial_port:
 				# URL-style device (e.g. socket://)
-				self.serial = serial.serial_for_url(
-					url=self.serial_port,
-					baudrate = 1200,
-					parity = serial.PARITY_NONE,
-					stopbits = serial.STOPBITS_TWO,
-					bytesize = serial.EIGHTBITS,
-					timeout = 2.0)
+				self.serial = serial.serial_for_url(url=self.serial_port, **kwargs)
 			else:
 				# Normal device path (e.g. /dev/ttyUSB0)
-				self.serial = serial.Serial(
-					port=self.serial_port,
-					baudrate=1200,
-					parity=serial.PARITY_NONE,
-					stopbits=serial.STOPBITS_TWO,
-					bytesize=serial.EIGHTBITS,
-					timeout=2.0
-				)
+				self.serial = serial.Serial(port=self.serial_port, **kwargs)
 		except serial.SerialException as e:
 			log.exception(e)
 

--- a/kamstrup_meter.py
+++ b/kamstrup_meter.py
@@ -89,13 +89,25 @@ class kamstrup(object):
 		self.parameters = parameters
 
 		try:
-			self.serial = serial.Serial(
-				port = self.serial_port,
-				baudrate = 1200,
-				parity = serial.PARITY_NONE,
-				stopbits = serial.STOPBITS_TWO,
-				bytesize = serial.EIGHTBITS,
-				timeout = 2.0)
+            if "://" in self.serial_port:
+                # URL-style device (e.g. socket://)
+                self.serial = serial.serial_for_url(
+                    url=self.serial_port,
+                    baudrate = 1200,
+                    parity = serial.PARITY_NONE,
+                    stopbits = serial.STOPBITS_TWO,
+                    bytesize = serial.EIGHTBITS,
+                    timeout = 2.0)
+            else:
+                # Normal device path (e.g. /dev/ttyUSB0)
+                self.serial = serial.Serial(
+                    port=self.serial_port,
+                    baudrate=1200,
+                    parity=serial.PARITY_NONE,
+                    stopbits=serial.STOPBITS_TWO,
+                    bytesize=serial.EIGHTBITS,
+                    timeout=2.0
+                )
 		except serial.SerialException as e:
 			log.exception(e)
 

--- a/kamstrup_meter.py
+++ b/kamstrup_meter.py
@@ -89,25 +89,25 @@ class kamstrup(object):
 		self.parameters = parameters
 
 		try:
-            if "://" in self.serial_port:
-                # URL-style device (e.g. socket://)
-                self.serial = serial.serial_for_url(
-                    url=self.serial_port,
-                    baudrate = 1200,
-                    parity = serial.PARITY_NONE,
-                    stopbits = serial.STOPBITS_TWO,
-                    bytesize = serial.EIGHTBITS,
-                    timeout = 2.0)
-            else:
-                # Normal device path (e.g. /dev/ttyUSB0)
-                self.serial = serial.Serial(
-                    port=self.serial_port,
-                    baudrate=1200,
-                    parity=serial.PARITY_NONE,
-                    stopbits=serial.STOPBITS_TWO,
-                    bytesize=serial.EIGHTBITS,
-                    timeout=2.0
-                )
+			if "://" in self.serial_port:
+				# URL-style device (e.g. socket://)
+				self.serial = serial.serial_for_url(
+					url=self.serial_port,
+					baudrate = 1200,
+					parity = serial.PARITY_NONE,
+					stopbits = serial.STOPBITS_TWO,
+					bytesize = serial.EIGHTBITS,
+					timeout = 2.0)
+			else:
+				# Normal device path (e.g. /dev/ttyUSB0)
+				self.serial = serial.Serial(
+					port=self.serial_port,
+					baudrate=1200,
+					parity=serial.PARITY_NONE,
+					stopbits=serial.STOPBITS_TWO,
+					bytesize=serial.EIGHTBITS,
+					timeout=2.0
+				)
 		except serial.SerialException as e:
 			log.exception(e)
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ The library can be configured to fit your needs using the config.yaml file. The 
 | authentication | Set this to true if your MQTT broker requires authentication |
 | username | Username to connect to broker |
 | password | Password to connect to broker | 
-| com_port | port of serial communication device |
+| com_port | Port of serial communication device. Supports both local ports (e.g., `/dev/ttyKamstrup`) and URL-style devices (e.g., `socket://rpi4-ser2net.local:20408`) |
 | parameters | List of parameters that are read and published to the configured MQTT topic. See [Meter parameters](#Kamstrup-meter-parameters) table. |
 | poll_interval | Meter readout interval in minutes (value should be less than 30 to prevent the meter from going in standby mode|
 


### PR DESCRIPTION
Hi Matthijs,

I  recently switched to using ser2net on a Raspberry Pi to expose the Kamstrup meter and other USB devices over TCP
This PR allows the kamstrup class to work with both local serial ports and networked serial devices:

- Added detection for URL-style ports (e.g., socket://host:port) and use serial.serial_for_url.
- Local serial ports (e.g., /dev/ttyUSB0) continue to work with serial.Serial.

In my case, this is how i connect with the ser2net service on the Rpi
```yaml
    serial_device:
        com_port: "socket://host:port"
```